### PR TITLE
set updated on user creation

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -145,8 +145,14 @@ class User {
      * @param LifecycleEventArgs $event
      */
     function setHistoryColumnsOnPrePersist(LifecycleEventArgs $event) {
+        $now = new \DateTime();
+
         if (!$this->getCreated()) {
-            $this->setCreated(new \DateTime());
+            $this->setCreated($now);
+        }
+
+        if(!$this->getUpdated()) {
+            $this->setUpdated($now);
         }
     }
 


### PR DESCRIPTION
The goal is that newly created users aren't instantly considered as stale users.