### PR TITLE
fix: handle null comment parameter in transaction endpoint

### DIFF
--- a/src/Controller/Api/TransactionController.php
+++ b/src/Controller/Api/TransactionController.php
@@ -52,7 +52,7 @@ class TransactionController extends AbstractController {
     function createUserTransactions($userId, Request $request, TransactionService $transactionService, EntityManagerInterface $entityManager) {
         $amount = $request->request->get('amount');
         $quantity = $request->request->get('quantity');
-        $comment = $request->request->get('comment');
+        $comment = $request->request->get('comment') ?? '';
         $recipientId = $request->request->get('recipientId');
         $articleId = $request->request->get('articleId');
 

--- a/src/Controller/Api/TransactionController.php
+++ b/src/Controller/Api/TransactionController.php
@@ -52,11 +52,11 @@ class TransactionController extends AbstractController {
     function createUserTransactions($userId, Request $request, TransactionService $transactionService, EntityManagerInterface $entityManager) {
         $amount = $request->request->get('amount');
         $quantity = $request->request->get('quantity');
-        $comment = $request->request->get('comment') ?? '';
+        $comment = $request->request->get('comment');
         $recipientId = $request->request->get('recipientId');
         $articleId = $request->request->get('articleId');
 
-        if (mb_strlen($comment) > 255) {
+        if (mb_strlen($comment ?? '') > 255) {
             throw new ParameterInvalidException('comment');
         }
 


### PR DESCRIPTION
Hello 👋🏼 

It's my first PR here.
I'm a user of strichliste, we have it in my hacker space next to the drinks' fridge.

Because PHP 8.x emits a deprecation warning when passing null to `mb_strlen()`.

This was breaking JSON responses when creating transactions without a comment.