### PR TITLE
Pass transaction instead of transactionId (fix Type Error)

### DIFF
--- a/src/Service/TransactionService.php
+++ b/src/Service/TransactionService.php
@@ -157,7 +157,7 @@ class TransactionService {
             }
 
             if ($transaction->isDeleted()) {
-                throw new TransactionNotDeletableException($transactionId);
+                throw new TransactionNotDeletableException($transaction);
             }
 
             $article = $transaction->getArticle();


### PR DESCRIPTION
`TransactionNotDeletableException` takes a Transaction, not an ID (int), so we should pass the Transaction instead of the ID.