### PR TITLE
Remove overrides of getCacheDir and getLogDir in Kernel

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -15,16 +15,6 @@ class Kernel extends BaseKernel
 
     const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
-    public function getCacheDir(): string
-    {
-        return $this->getProjectDir().'/var/cache/'.$this->environment;
-    }
-
-    public function getLogDir(): string
-    {
-        return $this->getProjectDir().'/var/log';
-    }
-
     public function registerBundles(): iterable
     {
         $contents = require $this->getProjectDir().'/config/bundles.php';


### PR DESCRIPTION
These functions are already provided by the `MicroKernelTrait` with the same default values (so this change is **NOT**  breaking), **but** they allow overriding the dirs using `APP_LOG_DIR` and `APP_CACHE_DIR`, which would greatly help with packaging for nix (where these functions are currently patched to set other dirs).

E.g. `getCacheDir()` in `MicroKernelTrait`:

```php
    public function getCacheDir(): string
    {
        if (null !== $dir = $_SERVER['APP_CACHE_DIR'] ?? null) {
            return $this->getEnvDir($dir);
        }

        return parent::getCacheDir();
    }
```

with `parent::getCacheDir()`:

```php
    public function getCacheDir(): string
    {
        return $this->getProjectDir().'/var/cache/'.$this->environment;
    }
```