### PR TITLE
Remove MySQL specific settings from doctrine.yaml

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -7,14 +7,6 @@ parameters:
 
 doctrine:
     dbal:
-        # configure these for your database server
-        driver: 'pdo_mysql'
-        server_version: '5.7'
-        charset: utf8mb4
-        default_table_options:
-            charset: utf8mb4
-            collate: utf8mb4_unicode_ci
-
         url: '%env(resolve:DATABASE_URL)%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'


### PR DESCRIPTION
Note: This is **BC breaking** for users who rely on these values being set by default. 

Right now, the `doctrine.yaml` contains configuration that is specific to MySQL. Using strichliste with, for example, postgresql will result in errors like:

> [critical] Error thrown while running command "doctrine:schema:create". Message: "An exception occurred in the driver: SQLSTATE[22023]: Invalid parameter value: 7 ERROR:  invalid value for parameter "client_encoding": "utf8mb4""

A workaround is possible by creating a `services_prod.yaml` in the config directory, which has the [highest priority](https://symfony.com/doc/current/configuration.html#configuration-environments) and removes/nulls the default settings:
```
doctrine:
  dbal:
    url: null
    charset: 'utf8'
    server_version: null
    default_table_options:
      charset: 'utf8'
      collate: null
```

Still, I think it would be cleaner to not have any settings specific to a single RDBMS in the default configuration.

Everything should be set via the `DATABASE_URL` (or by creating the `services_prod.yaml` with the settings needed for the specific installation, if `DATABASE_URL` is not sufficient).

As this might require users manually updating their configuration - maybe with all the other changes since the last release - this would be something for a 2.0.0 release of the backend?